### PR TITLE
fix tiktok transformations package link 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dispatch:
 ```
 
 ## Step 2: Install the package (skip if also using the `Tiktok` transformation package)
-If you  are **not** using the [Tiktok transformation package](https://github.com/fivetran/dbt_tiktok), include the following package version in your `packages.yml` file. If you are installing the transform package, the source package is automatically installed as a dependency.
+If you  are **not** using the [Tiktok transformation package](https://github.com/fivetran/dbt_tiktok_ads), include the following package version in your `packages.yml` file. If you are installing the transform package, the source package is automatically installed as a dependency.
 > TIP: Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instructions or [read the dbt docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 ```yaml
 packages:


### PR DESCRIPTION
**Please provide your name and company**
[Tiktok transformation package](https://github.com/fivetran/dbt_tiktok) gives a 404 and needs updating. My assumption is that it should direct users to https://github.com/fivetran/dbt_tiktok_ads